### PR TITLE
Add core dump option via abort variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ preloader:
 node -r make-promises-safe server.js
 ```
 
+### with core dumps
+
+You can also trigger a core dump when an unhandledRejection occurs by setting the enableRejectionCoreDumps environment variable. 
+
+```
+enableRejectionCoreDumps=true node server.js
+```
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -90,10 +90,11 @@ node -r make-promises-safe server.js
 
 ### with core dumps
 
-You can also trigger a core dump when an unhandledRejection occurs by setting the enableRejectionCoreDumps environment variable. 
+You can also create a core dump when an unhandled rejection occurs:
+
 
 ```
-enableRejectionCoreDumps=true node server.js
+require('make-promises-safe').abort = true
 ```
 ## License
 

--- a/example.js
+++ b/example.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// require('.')
+// require('.').abort = true;
 const http = require('http')
 const server = http.createServer(handle)
 

--- a/make-promises-safe.js
+++ b/make-promises-safe.js
@@ -9,9 +9,11 @@ if (process.listenerCount(event) === 0) {
 function setup () {
   process.on(event, function (err) {
     console.error(err)
-    if (process.env.enableRejectionCoreDumps) {
+    if (module.exports.abort) {
       process.abort()
     }
     process.exit(1)
   })
 }
+
+module.exports.abort = false

--- a/make-promises-safe.js
+++ b/make-promises-safe.js
@@ -9,6 +9,9 @@ if (process.listenerCount(event) === 0) {
 function setup () {
   process.on(event, function (err) {
     console.error(err)
+    if (process.env.enableRejectionCoreDumps) {
+      process.abort()
+    }
     process.exit(1)
   })
 }


### PR DESCRIPTION
Hey, 

Would something like this work for #4 (abort and core dumps)? 

I thought of passing something via the require call but using an environment variable seemed less intrusive. Really useful module by the way. Been caught more than once by unhandled rejections.

Nigel. 