### PR TITLE
Always add listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ It implements the deprecation [DEP0018][unhandled] of Node.js in versions 6+.
 Using Promises without this module might cause file descriptor and memory
 leaks.
 
+**It is important that this module is only used in top-level program code, not
+in reusable modules!**
+
 ## The Problem
 
 Node.js crashes if there is an uncaught exception, while it does not

--- a/make-promises-safe.js
+++ b/make-promises-safe.js
@@ -2,18 +2,12 @@
 
 const event = 'unhandledRejection'
 
-if (process.listenerCount(event) === 0) {
-  setup()
-}
-
-function setup () {
-  process.on(event, function (err) {
-    console.error(err)
-    if (module.exports.abort) {
-      process.abort()
-    }
-    process.exit(1)
-  })
-}
+process.on(event, function (err) {
+  console.error(err)
+  if (module.exports.abort) {
+    process.abort()
+  }
+  process.exit(1)
+})
 
 module.exports.abort = false


### PR DESCRIPTION
I tried to come up with a warning in case other listeners are already set when loading `make-promises-safe` but I could not come up with anything useful. @mcollina why do you think we should warn about other listeners? 

Fixes: https://github.com/mcollina/make-promises-safe/issues/13