### PR TITLE
Stronger typechecking

### DIFF
--- a/make-promises-safe.d.ts
+++ b/make-promises-safe.d.ts
@@ -1,2 +1,2 @@
 export let abort:string;
-export let logError: (...objs: any[]) => void;
+export let logError:(reason:Error|any) => void;


### PR DESCRIPTION
Normally, the `reason` object will be an `Error`, but it can be any type. Is `Error | any` necessary?